### PR TITLE
Implement `PartialEq` and `Eq` for `ser::Error`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Added
+- `ser::Error` now implements `PartialEq` and `Eq`.
 
 ## 0.3.0 - 2023-04-06
 ### Changed

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -702,7 +702,7 @@ impl ser::SerializeStruct for SerializeStruct<'_> {
 ///
 /// assert_eq!(format!("{}", Error::custom("foo")), "foo");
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Error(pub String);
 
 impl Display for Error {


### PR DESCRIPTION
This allows for easier equality comparisons.