### PR TITLE
Remove need to use `Tokens` wrapper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## Unreleased
+### Added
+- `Tokens` now implements `IntoIterator<Item = Token>`.
+- `&Tokens` now implements `IntoIterator<Item = &Token>`.
+- The `token` module is now public, containing both `Token` (which is also exposed in the root module) and `Tokens`.
+### Changed
+- `de::Builder::tokens()` now accepts any type that implements `Clone + IntoIterator<Item = Token>`.
+- `Tokens` is no longer exposed in the root module, instead being available at `token::Tokens`.
+- The internals of `Tokens` are no longer public. `Tokens` can no longer be constructed by user code, and is now only returned by the `Serializer`.
+- Comparison with a `Tokens` can now be done with any type that implements `IntoIterator<Item = &Token>`.
 
 ## 0.6.0 - 2023-11-19
 ### Changed

--- a/README.md
+++ b/README.md
@@ -23,12 +23,11 @@ use serde::Serialize;
 use serde_assert::{
     Serializer,
     Token,
-    Tokens,
 };
 
 let serializer = Serializer::builder().build();
 
-assert_ok_eq!(true.serialize(&serializer), Tokens(vec![Token::Bool(true)]));
+assert_ok_eq!(true.serialize(&serializer), [Token::Bool(true)]);
 ```
 
 ### Testing Deserialization
@@ -40,12 +39,9 @@ use serde::Deserialize;
 use serde_assert::{
     Deserializer,
     Token,
-    Tokens,
 };
 
-let mut deserializer = Deserializer::builder()
-    .tokens(Tokens(vec![Token::Bool(true)]))
-    .build();
+let mut deserializer = Deserializer::builder().tokens([Token::Bool(true)]).build();
 
 assert_ok_eq!(bool::deserialize(&mut deserializer), true);
 ```

--- a/src/de.rs
+++ b/src/de.rs
@@ -43,9 +43,9 @@ use serde::{
 
 /// Deserializer for testing [`Deserialize`] implementations.
 ///
-/// A deserializer is constructed using [`Tokens`] representing the serialized value to be
-/// deserialized. The value that is output can be compared against an expected value to ensure
-/// deserialization works correctly.
+/// A deserializer is constructed from a sequence of [`Token`]s representing the serialized value
+/// to be deserialized. The value that is output can be compared against an expected value to
+/// ensure deserialization works correctly.
 ///
 /// # Configuration
 /// The following options can be configured on the [`Builder`]:
@@ -1177,7 +1177,7 @@ impl<'a, 'de> de::Deserializer<'de> for EnumDeserializer<'a, 'de> {
 /// Construction of a `Deserializer` follows the builder pattern. Configuration options can be set
 /// on the `Builder`, and then the actual `Deserializer` is constructed by calling [`build()`].
 ///
-/// Note that providing [`Tokens`] using the [`tokens()`] method is required.
+/// Note that providing a sequence of [`Token`]s using the [`tokens()`] method is required.
 ///
 /// # Example
 /// ``` rust
@@ -1205,7 +1205,7 @@ pub struct Builder<T> {
 }
 
 impl<T> Builder<T> {
-    /// Provides the [`Tokens`] to be used as the input source during deserialization.
+    /// Provides the sequence of [`Token`]s to be used as the input source during deserialization.
     ///
     /// Calling this method before [`build()`] is required.
     ///
@@ -1371,7 +1371,7 @@ impl<T> Default for Builder<T> {
 /// ```
 #[derive(Debug, PartialEq)]
 pub enum Error {
-    /// The [`Deserializer`] reached the end of the input [`Tokens`] before deserialization was
+    /// The [`Deserializer`] reached the end of the input [`Token`]s before deserialization was
     /// completed.
     EndOfTokens,
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -20,7 +20,7 @@
 
 use crate::{
     token,
-    token::IntoTokens,
+    token::Tokens,
     Token,
 };
 use alloc::string::{
@@ -1305,7 +1305,7 @@ impl<T> Builder<T> {
 
 impl<T> Builder<T>
 where
-    T: Clone + IntoTokens,
+    T: Clone + IntoIterator<Item = Token>,
 {
     /// Build a new [`Deserializer`] using this `Builder`.
     ///
@@ -1328,12 +1328,13 @@ where
     /// This method will panic if [`Builder::tokens()`] was never called.
     pub fn build<'a>(&mut self) -> Deserializer<'a> {
         Deserializer {
-            tokens: token::Iter::new(
+            tokens: token::Iter::new(Tokens(
                 self.tokens
                     .clone()
                     .expect("no tokens provided to `Deserializer` `Builder`")
-                    .into_tokens(),
-            ),
+                    .into_iter()
+                    .collect(),
+            )),
 
             revisited_token: None,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,14 +114,11 @@ extern crate alloc;
 
 pub mod de;
 pub mod ser;
-
-mod token;
+pub mod token;
 
 #[doc(inline)]
 pub use de::Deserializer;
 #[doc(inline)]
 pub use ser::Serializer;
-pub use token::{
-    Token,
-    Tokens,
-};
+#[doc(inline)]
+pub use token::Token;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,12 +68,9 @@
 //! use serde_assert::{
 //!     Deserializer,
 //!     Token,
-//!     Tokens,
 //! };
 //!
-//! let mut deserializer = Deserializer::builder()
-//!     .tokens(Tokens(vec![Token::Bool(true)]))
-//!     .build();
+//! let mut deserializer = Deserializer::builder().tokens([Token::Bool(true)]).build();
 //!
 //! assert_ok_eq!(bool::deserialize(&mut deserializer), true);
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,11 @@
 //! use serde_assert::{
 //!     Serializer,
 //!     Token,
-//!     Tokens,
 //! };
 //!
 //! let serializer = Serializer::builder().build();
 //!
-//! assert_ok_eq!(true.serialize(&serializer), Tokens(vec![Token::Bool(true)]));
+//! assert_ok_eq!(true.serialize(&serializer), [Token::Bool(true)]);
 //! ```
 //!
 //! ## Arbitrary Ordering
@@ -37,7 +36,6 @@
 //! use serde_assert::{
 //!     Serializer,
 //!     Token,
-//!     Tokens,
 //! };
 //!
 //! let serializer = Serializer::builder().build();
@@ -49,11 +47,11 @@
 //!
 //! assert_ok_eq!(
 //!     set.serialize(&serializer),
-//!     Tokens(vec![
+//!     [
 //!         Token::Seq { len: Some(3) },
 //!         Token::Unordered(&[&[Token::U32(1)], &[Token::U32(2)], &[Token::U32(3)],]),
 //!         Token::SeqEnd
-//!     ])
+//!     ]
 //! );
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,15 @@
 //!
 //! This library provides a [`Serializer`] and [`Deserializer`] to be used in writing unit tests to
 //! assert the behavior of manual [`Serialize`] and [`Deserialize`] implementations, respectively.
-//! The implementation behavior can be verified by using [`Tokens`] representing an arbitrary
-//! serialized state.
+//! The implementation behavior can be verified by using a sequence of [`Token`]s representing an
+//! arbitrary serialized state.
 //!
 //! # Testing Serialization
-//! The [`Serializer`] returns [`Tokens`] representing the serialization of a value. The returned
-//! `Tokens` can be checked to be equal to an expected value. Since [`Serialize::serialize()`]
-//! returns a `Result<Tokens, Error>`, it is recommended to use the [`claims`] crate to check that
-//! the returned value is both `Ok` and equal to the expected `Tokens`.
+//! The [`Serializer`] returns a sequence of [`Token`]s representing the serialization of a value.
+//! The returned `Token`s can be checked to be equal to an expected value. Since
+//! [`Serialize::serialize()`] returns a `Result<Tokens, Error>`, it is recommended to use the
+//! [`claims`] crate to check that the returned value is both `Ok` and equal to the expected
+//! sequence of `Token`s.
 //!
 //! ```
 //! use claims::assert_ok_eq;
@@ -56,9 +57,9 @@
 //! ```
 //!
 //! # Testing Deserialization
-//! A [`Deserializer`] is constructed by providing [`Tokens`] to be deserialized into a value.
-//! During testing, the [`claims`] crate can be used to assert that deserialization succeeds and
-//! returns the expected value.
+//! A [`Deserializer`] is constructed by providing a sequence of [`Token`]s to be deserialized into
+//! a value. During testing, the [`claims`] crate can be used to assert that deserialization
+//! succeeds and returns the expected value.
 //!
 //! ```
 //! use claims::assert_ok_eq;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -102,7 +102,7 @@ pub enum SerializeStructAs {
 /// Serializer for testing [`Serialize`] implementations.
 ///
 /// This serializer outputs [`Tokens`] representing the serialized value. The `Tokens` can be
-/// compared against expected `Tokens` to ensure the serialization is correct.
+/// compared against an expected sequence of [`Token`]s to ensure the serialization is correct.
 ///
 /// # Configuration
 /// The following options can be configured on the [`Builder`]:

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -12,12 +12,11 @@
 //! use serde_assert::{
 //!     Serializer,
 //!     Token,
-//!     Tokens,
 //! };
 //!
 //! let serializer = Serializer::builder().build();
 //!
-//! assert_ok_eq!(true.serialize(&serializer), Tokens(vec![Token::Bool(true)]));
+//! assert_ok_eq!(true.serialize(&serializer), [Token::Bool(true)]);
 //! ```
 
 use crate::{
@@ -62,7 +61,6 @@ use serde::{
 ///     ser::SerializeStructAs,
 ///     Serializer,
 ///     Token,
-///     Tokens,
 /// };
 /// use serde_derive::Serialize;
 ///
@@ -82,12 +80,12 @@ use serde::{
 ///
 /// assert_ok_eq!(
 ///     some_struct.serialize(&serializer),
-///     Tokens(vec![
+///     [
 ///         Token::Seq { len: Some(2) },
 ///         Token::Bool(false),
 ///         Token::U32(42),
 ///         Token::SeqEnd,
-///     ])
+///     ]
 /// );
 /// ```
 #[derive(Clone, Copy, Debug)]
@@ -125,12 +123,11 @@ pub enum SerializeStructAs {
 /// use serde_assert::{
 ///     Serializer,
 ///     Token,
-///     Tokens,
 /// };
 ///
 /// let serializer = Serializer::builder().build();
 ///
-/// assert_ok_eq!(true.serialize(&serializer), Tokens(vec![Token::Bool(true)]));
+/// assert_ok_eq!(true.serialize(&serializer), [Token::Bool(true)]);
 /// ```
 ///
 /// [`is_human_readable()`]: Builder::is_human_readable()
@@ -461,7 +458,6 @@ impl Builder {
     ///     ser::SerializeStructAs,
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     /// use serde_derive::Serialize;
     ///
@@ -481,12 +477,12 @@ impl Builder {
     ///
     /// assert_ok_eq!(
     ///     some_struct.serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::Seq { len: Some(2) },
     ///         Token::Bool(false),
     ///         Token::U32(42),
     ///         Token::SeqEnd,
-    ///     ])
+    ///     ]
     /// );
     /// ```
     pub fn serialize_struct_as(&mut self, serialize_struct_as: SerializeStructAs) -> &mut Self {
@@ -729,10 +725,7 @@ mod tests {
         SerializeStructAs,
         Serializer,
     };
-    use crate::{
-        Token,
-        Tokens,
-    };
+    use crate::Token;
     use alloc::{
         borrow::ToOwned,
         format,
@@ -756,35 +749,35 @@ mod tests {
     fn serialize_bool() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(true.serialize(&serializer), Tokens(vec![Token::Bool(true)]));
+        assert_ok_eq!(true.serialize(&serializer), [Token::Bool(true)]);
     }
 
     #[test]
     fn serialize_i8() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42i8.serialize(&serializer), Tokens(vec![Token::I8(42)]));
+        assert_ok_eq!(42i8.serialize(&serializer), [Token::I8(42)]);
     }
 
     #[test]
     fn serialize_i16() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42i16.serialize(&serializer), Tokens(vec![Token::I16(42)]));
+        assert_ok_eq!(42i16.serialize(&serializer), [Token::I16(42)]);
     }
 
     #[test]
     fn serialize_i32() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42i32.serialize(&serializer), Tokens(vec![Token::I32(42)]));
+        assert_ok_eq!(42i32.serialize(&serializer), [Token::I32(42)]);
     }
 
     #[test]
     fn serialize_i64() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42i64.serialize(&serializer), Tokens(vec![Token::I64(42)]));
+        assert_ok_eq!(42i64.serialize(&serializer), [Token::I64(42)]);
     }
 
     #[cfg(has_i128)]
@@ -792,35 +785,35 @@ mod tests {
     fn serialize_i128() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42i128.serialize(&serializer), Tokens(vec![Token::I128(42)]));
+        assert_ok_eq!(42i128.serialize(&serializer), [Token::I128(42)]);
     }
 
     #[test]
     fn serialize_u8() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42u8.serialize(&serializer), Tokens(vec![Token::U8(42)]));
+        assert_ok_eq!(42u8.serialize(&serializer), [Token::U8(42)]);
     }
 
     #[test]
     fn serialize_u16() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42u16.serialize(&serializer), Tokens(vec![Token::U16(42)]));
+        assert_ok_eq!(42u16.serialize(&serializer), [Token::U16(42)]);
     }
 
     #[test]
     fn serialize_u32() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42u32.serialize(&serializer), Tokens(vec![Token::U32(42)]));
+        assert_ok_eq!(42u32.serialize(&serializer), [Token::U32(42)]);
     }
 
     #[test]
     fn serialize_u64() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42u64.serialize(&serializer), Tokens(vec![Token::U64(42)]));
+        assert_ok_eq!(42u64.serialize(&serializer), [Token::U64(42)]);
     }
 
     #[cfg(has_i128)]
@@ -828,38 +821,35 @@ mod tests {
     fn serialize_u128() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42u128.serialize(&serializer), Tokens(vec![Token::U128(42)]));
+        assert_ok_eq!(42u128.serialize(&serializer), [Token::U128(42)]);
     }
 
     #[test]
     fn serialize_f32() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42f32.serialize(&serializer), Tokens(vec![Token::F32(42.)]));
+        assert_ok_eq!(42f32.serialize(&serializer), [Token::F32(42.)]);
     }
 
     #[test]
     fn serialize_f64() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(42f64.serialize(&serializer), Tokens(vec![Token::F64(42.)]));
+        assert_ok_eq!(42f64.serialize(&serializer), [Token::F64(42.)]);
     }
 
     #[test]
     fn serialize_char() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!('a'.serialize(&serializer), Tokens(vec![Token::Char('a')]));
+        assert_ok_eq!('a'.serialize(&serializer), [Token::Char('a')]);
     }
 
     #[test]
     fn serialize_str() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(
-            "a".serialize(&serializer),
-            Tokens(vec![Token::Str("a".to_owned())])
-        );
+        assert_ok_eq!("a".serialize(&serializer), [Token::Str("a".to_owned())]);
     }
 
     #[test]
@@ -868,7 +858,7 @@ mod tests {
 
         assert_ok_eq!(
             Bytes::new(b"a").serialize(&serializer),
-            Tokens(vec![Token::Bytes(b"a".to_vec())])
+            [Token::Bytes(b"a".to_vec())]
         );
     }
 
@@ -876,10 +866,7 @@ mod tests {
     fn serialize_none() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(
-            Option::<()>::None.serialize(&serializer),
-            Tokens(vec![Token::None])
-        );
+        assert_ok_eq!(Option::<()>::None.serialize(&serializer), [Token::None]);
     }
 
     #[test]
@@ -888,7 +875,7 @@ mod tests {
 
         assert_ok_eq!(
             Some(true).serialize(&serializer),
-            Tokens(vec![Token::Some, Token::Bool(true)])
+            [Token::Some, Token::Bool(true)]
         );
     }
 
@@ -896,7 +883,7 @@ mod tests {
     fn serialize_unit() {
         let serializer = Serializer::builder().build();
 
-        assert_ok_eq!(().serialize(&serializer), Tokens(vec![Token::Unit]));
+        assert_ok_eq!(().serialize(&serializer), [Token::Unit]);
     }
 
     #[test]
@@ -908,7 +895,7 @@ mod tests {
 
         assert_ok_eq!(
             Unit.serialize(&serializer),
-            Tokens(vec![Token::UnitStruct { name: "Unit" }])
+            [Token::UnitStruct { name: "Unit" }]
         );
     }
 
@@ -923,11 +910,11 @@ mod tests {
 
         assert_ok_eq!(
             Unit::Variant.serialize(&serializer),
-            Tokens(vec![Token::UnitVariant {
+            [Token::UnitVariant {
                 name: "Unit",
                 variant_index: 0,
                 variant: "Variant"
-            }])
+            }]
         );
     }
 
@@ -940,10 +927,7 @@ mod tests {
 
         assert_ok_eq!(
             Newtype(false).serialize(&serializer),
-            Tokens(vec![
-                Token::NewtypeStruct { name: "Newtype" },
-                Token::Bool(false)
-            ])
+            [Token::NewtypeStruct { name: "Newtype" }, Token::Bool(false)]
         );
     }
 
@@ -958,14 +942,14 @@ mod tests {
 
         assert_ok_eq!(
             Newtype::Variant(false).serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::NewtypeVariant {
                     name: "Newtype",
                     variant_index: 0,
                     variant: "Variant"
                 },
                 Token::Bool(false)
-            ])
+            ]
         );
     }
 
@@ -975,13 +959,13 @@ mod tests {
 
         assert_ok_eq!(
             vec![1i8, 2i8, 3i8].serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::Seq { len: Some(3) },
                 Token::I8(1),
                 Token::I8(2),
                 Token::I8(3),
                 Token::SeqEnd
-            ]),
+            ],
         );
     }
 
@@ -996,7 +980,7 @@ mod tests {
 
         assert_ok_eq!(
             set.serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::Seq { len: Some(3) },
                 Token::Unordered(&[
                     &[Token::Char('a')],
@@ -1004,7 +988,7 @@ mod tests {
                     &[Token::Char('c')],
                 ]),
                 Token::SeqEnd,
-            ])
+            ]
         );
     }
 
@@ -1014,13 +998,13 @@ mod tests {
 
         assert_ok_eq!(
             (1i8, 2i16, 3i32).serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::Tuple { len: 3 },
                 Token::I8(1),
                 Token::I16(2),
                 Token::I32(3),
                 Token::TupleEnd
-            ]),
+            ],
         );
     }
 
@@ -1033,7 +1017,7 @@ mod tests {
 
         assert_ok_eq!(
             TupleStruct(1i8, 2i16, 3i32).serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::TupleStruct {
                     name: "TupleStruct",
                     len: 3
@@ -1042,7 +1026,7 @@ mod tests {
                 Token::I16(2),
                 Token::I32(3),
                 Token::TupleStructEnd
-            ]),
+            ],
         );
     }
 
@@ -1057,7 +1041,7 @@ mod tests {
 
         assert_ok_eq!(
             Tuple::Variant(1i8, 2i16, 3i32).serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::TupleVariant {
                     name: "Tuple",
                     variant_index: 0,
@@ -1068,7 +1052,7 @@ mod tests {
                 Token::I16(2),
                 Token::I32(3),
                 Token::TupleVariantEnd
-            ]),
+            ],
         );
     }
 
@@ -1083,7 +1067,7 @@ mod tests {
 
         assert_ok_eq!(
             map.serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::Map { len: Some(3) },
                 Token::Unordered(&[
                     &[Token::I8(1), Token::Char('a')],
@@ -1091,7 +1075,7 @@ mod tests {
                     &[Token::I8(3), Token::Char('c')],
                 ]),
                 Token::MapEnd,
-            ])
+            ]
         );
     }
 
@@ -1113,7 +1097,7 @@ mod tests {
                 c: "foo".to_owned(),
             }
             .serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::Struct {
                     name: "Struct",
                     len: 3,
@@ -1125,7 +1109,7 @@ mod tests {
                 Token::Field("c"),
                 Token::Str("foo".to_owned()),
                 Token::StructEnd,
-            ])
+            ]
         );
     }
 
@@ -1152,7 +1136,7 @@ mod tests {
                 c: "foo".to_owned(),
             }
             .serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::Struct {
                     name: "Struct",
                     len: 2,
@@ -1163,7 +1147,7 @@ mod tests {
                 Token::Field("c"),
                 Token::Str("foo".to_owned()),
                 Token::StructEnd,
-            ])
+            ]
         );
     }
 
@@ -1185,12 +1169,12 @@ mod tests {
 
         assert_ok_eq!(
             some_struct.serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::Seq { len: Some(2) },
                 Token::Bool(false),
                 Token::U32(42),
                 Token::SeqEnd,
-            ])
+            ]
         );
     }
 
@@ -1210,7 +1194,7 @@ mod tests {
                 c: "foo".to_owned(),
             }
             .serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::StructVariant {
                     name: "Struct",
                     variant_index: 0,
@@ -1224,7 +1208,7 @@ mod tests {
                 Token::Field("c"),
                 Token::Str("foo".to_owned()),
                 Token::StructVariantEnd,
-            ])
+            ]
         );
     }
 
@@ -1253,7 +1237,7 @@ mod tests {
                 c: "foo".to_owned(),
             }
             .serialize(&serializer),
-            Tokens(vec![
+            [
                 Token::StructVariant {
                     name: "Struct",
                     variant_index: 0,
@@ -1266,7 +1250,7 @@ mod tests {
                 Token::Field("c"),
                 Token::Str("foo".to_owned()),
                 Token::StructVariantEnd,
-            ])
+            ]
         );
     }
 
@@ -1287,7 +1271,7 @@ mod tests {
 
         assert_ok_eq!(
             CollectedString("foo".to_owned()).serialize(&serializer),
-            Tokens(vec![Token::Str("foo".to_owned())])
+            [Token::Str("foo".to_owned())]
         );
     }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -20,8 +20,8 @@
 //! ```
 
 use crate::{
+    token::Tokens,
     Token,
-    Tokens,
 };
 use alloc::{
     borrow::ToOwned,

--- a/src/token.rs
+++ b/src/token.rs
@@ -1223,7 +1223,7 @@ where
     }
 }
 
-impl PartialEq for Tokens {
+impl Tokens {
     fn eq(&self, other: &Self) -> bool {
         let mut self_iter = self.0.iter();
         let mut other_iter = other.0.iter();
@@ -1281,6 +1281,36 @@ impl PartialEq for Tokens {
                 }
             }
         }
+    }
+}
+
+impl PartialEq for Tokens {
+    fn eq(&self, other: &Self) -> bool {
+        self.eq(other)
+    }
+}
+
+impl PartialEq<Vec<Token>> for Tokens {
+    fn eq(&self, other: &Vec<Token>) -> bool {
+        self.eq(&other.clone().into_tokens())
+    }
+}
+
+impl<const N: usize> PartialEq<[Token; N]> for Tokens {
+    fn eq(&self, other: &[Token; N]) -> bool {
+        self.eq(&other.clone().into_tokens())
+    }
+}
+
+impl PartialEq<Tokens> for Vec<Token> {
+    fn eq(&self, other: &Tokens) -> bool {
+        other.eq(&self.clone().into_tokens())
+    }
+}
+
+impl<const N: usize> PartialEq<Tokens> for [Token; N] {
+    fn eq(&self, other: &Tokens) -> bool {
+        other.eq(&self.clone().into_tokens())
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1388,6 +1388,30 @@ impl Drop for Iter<'_> {
     }
 }
 
+/// Indicates that a type can be converted into `Tokens`.
+pub trait IntoTokens {
+    /// Creates a sequence of tokens from the value.
+    fn into_tokens(self) -> Tokens;
+}
+
+impl IntoTokens for Tokens {
+    fn into_tokens(self) -> Tokens {
+        self
+    }
+}
+
+impl IntoTokens for Vec<Token> {
+    fn into_tokens(self) -> Tokens {
+        Tokens(self)
+    }
+}
+
+impl<const N: usize> IntoTokens for [Token; N] {
+    fn into_tokens(self) -> Tokens {
+        Tokens(self.to_vec())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/src/token.rs
+++ b/src/token.rs
@@ -219,7 +219,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();

--- a/src/token.rs
+++ b/src/token.rs
@@ -7,6 +7,7 @@
 use alloc::{
     slice,
     string::String,
+    vec,
     vec::Vec,
 };
 use core::{
@@ -1234,6 +1235,15 @@ where
                 }
             }
         }
+    }
+}
+
+impl IntoIterator for Tokens {
+    type Item = Token;
+    type IntoIter = vec::IntoIter<Token>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,8 +1,11 @@
 //! Tokens representing a serialized object.
 //!
 //! This module provides a [`Token`] type for representing a serialized value, as well as a
-//! [`Tokens`] type containing a set of `Token`s. `Tokens` can be compared for equality, which is
-//! useful for asserting whether serialized `Tokens` are as expected.
+//! [`Tokens`] type containing a set of `Token`s. `Tokens` are returned by a [`Serializer`] and can
+//! be compared against a sequence of `Token`s to verify equality, which is useful for asserting
+//! whether serialized `Tokens` are as expected.
+//!
+//! [`Serializer`]: crate::Serializer
 
 use alloc::{
     slice,
@@ -29,10 +32,10 @@ use serde::de::Unexpected;
 /// A `Token` is a single serialization output produced by the [`Serializer`]. The one exception to
 /// this is the [`Unordered`] variant, which contains multiple sets of tokens that can be in any
 /// order. This is never produced by the `Serializer`, and is for use when comparing equality of
-/// [`Tokens`].
+/// sequences of [`Token`]s.
 ///
-/// Normally, `Token`s are used within the [`Tokens`] struct to either compare against the output
-/// of a [`Serializer`] or to be used as input to a [`Deserializer`].
+/// Normally, a sequence of `Token`s are used to either compare against the output of a
+/// [`Serializer`] or to be used as input to a [`Deserializer`].
 ///
 /// [`Deserializer`]: crate::Deserializer
 /// [`Serializer`]: crate::Serializer
@@ -1069,14 +1072,14 @@ impl<'a> From<&'a Token> for Unexpected<'a> {
     }
 }
 
-/// An ordered set of [`Token`]s.
+/// A sequence of [`Token`]s output by a [`Serializer`].
 ///
-/// This is simply a wrapper around a [`Vec<Token>`], providing a custom [`PartialEq`]
-/// implementation for comparing with tokens output from a [`Serializer`].
+/// `Tokens` can be compared with any other sequence of `Token`s to assert that the serialized
+/// values are as expected.
 ///
 /// # Examples
 ///
-/// `Tokens` are output from a [`Serializer`] and are used as input to a [`Deserializer`].
+/// `Tokens` are output from a [`Serializer`] and can be compared against a sequence of `Token`s.
 ///
 /// ## Serialization
 ///
@@ -1095,15 +1098,27 @@ impl<'a> From<&'a Token> for Unexpected<'a> {
 ///
 /// ## Deserialization
 ///
+/// `Tokens` obtained from a [`Serializer`] can be used as input to a [`Deserializer`].
+///
 /// ``` rust
-/// use claims::assert_ok_eq;
-/// use serde::Deserialize;
+/// use claims::{
+///     assert_ok,
+///     assert_ok_eq,
+/// };
+/// use serde::{
+///     Deserialize,
+///     Serialize,
+/// };
 /// use serde_assert::{
 ///     Deserializer,
+///     Serializer,
 ///     Token,
 /// };
 ///
-/// let mut deserializer = Deserializer::builder().tokens([Token::Bool(true)]).build();
+/// let serializer = Serializer::builder().build();
+/// let mut deserializer = Deserializer::builder()
+///     .tokens(assert_ok!(true.serialize(&serializer)))
+///     .build();
 ///
 /// assert_ok_eq!(bool::deserialize(&mut deserializer), true);
 /// ```

--- a/src/token.rs
+++ b/src/token.rs
@@ -7,6 +7,7 @@
 use alloc::{
     slice,
     string::String,
+    vec,
     vec::Vec,
 };
 use core::{
@@ -1242,25 +1243,34 @@ impl PartialEq for Tokens {
 
 impl PartialEq<Vec<Token>> for Tokens {
     fn eq(&self, other: &Vec<Token>) -> bool {
-        self.eq(&other.clone().into_tokens())
+        self.eq(&Tokens(other.clone()))
     }
 }
 
 impl<const N: usize> PartialEq<[Token; N]> for Tokens {
     fn eq(&self, other: &[Token; N]) -> bool {
-        self.eq(&other.clone().into_tokens())
+        self.eq(&Tokens(other.to_vec()))
     }
 }
 
 impl PartialEq<Tokens> for Vec<Token> {
     fn eq(&self, other: &Tokens) -> bool {
-        other.eq(&self.clone().into_tokens())
+        other.eq(&Tokens(self.clone()))
     }
 }
 
 impl<const N: usize> PartialEq<Tokens> for [Token; N] {
     fn eq(&self, other: &Tokens) -> bool {
-        other.eq(&self.clone().into_tokens())
+        other.eq(&Tokens(self.to_vec()))
+    }
+}
+
+impl IntoIterator for Tokens {
+    type Item = Token;
+    type IntoIter = vec::IntoIter<Token>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 
@@ -1365,30 +1375,6 @@ impl Drop for Iter<'_> {
                 self.cap,
             )
         };
-    }
-}
-
-/// Indicates that a type can be converted into `Tokens`.
-pub trait IntoTokens {
-    /// Creates a sequence of tokens from the value.
-    fn into_tokens(self) -> Tokens;
-}
-
-impl IntoTokens for Tokens {
-    fn into_tokens(self) -> Tokens {
-        self
-    }
-}
-
-impl IntoTokens for Vec<Token> {
-    fn into_tokens(self) -> Tokens {
-        Tokens(self)
-    }
-}
-
-impl<const N: usize> IntoTokens for [Token; N] {
-    fn into_tokens(self) -> Tokens {
-        Tokens(self.to_vec())
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -47,12 +47,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(true.serialize(&serializer), Tokens(vec![Token::Bool(true)]));
+    /// assert_ok_eq!(true.serialize(&serializer), [Token::Bool(true)]);
     /// ```
     Bool(bool),
 
@@ -65,12 +64,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(42i8.serialize(&serializer), Tokens(vec![Token::I8(42)]));
+    /// assert_ok_eq!(42i8.serialize(&serializer), [Token::I8(42)]);
     /// ```
     I8(i8),
 
@@ -83,12 +81,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(42i16.serialize(&serializer), Tokens(vec![Token::I16(42)]));
+    /// assert_ok_eq!(42i16.serialize(&serializer), [Token::I16(42)]);
     /// ```
     I16(i16),
 
@@ -101,12 +98,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(42i32.serialize(&serializer), Tokens(vec![Token::I32(42)]));
+    /// assert_ok_eq!(42i32.serialize(&serializer), [Token::I32(42)]);
     /// ```
     I32(i32),
 
@@ -119,12 +115,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(42i64.serialize(&serializer), Tokens(vec![Token::I64(42)]));
+    /// assert_ok_eq!(42i64.serialize(&serializer), [Token::I64(42)]);
     /// ```
     I64(i64),
 
@@ -138,12 +133,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(42i128.serialize(&serializer), Tokens(vec![Token::I128(42)]));
+    /// assert_ok_eq!(42i128.serialize(&serializer), [Token::I128(42)]);
     /// ```
     I128(i128),
 
@@ -156,12 +150,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(42u8.serialize(&serializer), Tokens(vec![Token::U8(42)]));
+    /// assert_ok_eq!(42u8.serialize(&serializer), [Token::U8(42)]);
     /// ```
     U8(u8),
 
@@ -174,12 +167,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(42u16.serialize(&serializer), Tokens(vec![Token::U16(42)]));
+    /// assert_ok_eq!(42u16.serialize(&serializer), [Token::U16(42)]);
     /// ```
     U16(u16),
 
@@ -192,12 +184,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(42u32.serialize(&serializer), Tokens(vec![Token::U32(42)]));
+    /// assert_ok_eq!(42u32.serialize(&serializer), [Token::U32(42)]);
     /// ```
     U32(u32),
 
@@ -210,12 +201,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(42u64.serialize(&serializer), Tokens(vec![Token::U64(42)]));
+    /// assert_ok_eq!(42u64.serialize(&serializer), [Token::U64(42)]);
     /// ```
     U64(u64),
 
@@ -234,7 +224,7 @@ pub enum Token {
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(42u128.serialize(&serializer), Tokens(vec![Token::U128(42)]));
+    /// assert_ok_eq!(42u128.serialize(&serializer), [Token::U128(42)]);
     /// ```
     U128(u128),
 
@@ -247,15 +237,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(
-    ///     42.0f32.serialize(&serializer),
-    ///     Tokens(vec![Token::F32(42.0)])
-    /// );
+    /// assert_ok_eq!(42.0f32.serialize(&serializer), [Token::F32(42.0)]);
     /// ```
     F32(f32),
 
@@ -268,15 +254,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(
-    ///     42.0f64.serialize(&serializer),
-    ///     Tokens(vec![Token::F64(42.0)])
-    /// );
+    /// assert_ok_eq!(42.0f64.serialize(&serializer), [Token::F64(42.0)]);
     /// ```
     F64(f64),
 
@@ -289,12 +271,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!('a'.serialize(&serializer), Tokens(vec![Token::Char('a')]));
+    /// assert_ok_eq!('a'.serialize(&serializer), [Token::Char('a')]);
     /// ```
     Char(char),
 
@@ -307,15 +288,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(
-    ///     "foo".serialize(&serializer),
-    ///     Tokens(vec![Token::Str("foo".to_owned())])
-    /// );
+    /// assert_ok_eq!("foo".serialize(&serializer), [Token::Str("foo".to_owned())]);
     /// ```
     Str(String),
 
@@ -328,7 +305,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     /// use serde_bytes::Bytes;
     ///
@@ -336,7 +312,7 @@ pub enum Token {
     ///
     /// assert_ok_eq!(
     ///     Bytes::new(b"foo").serialize(&serializer),
-    ///     Tokens(vec![Token::Bytes(b"foo".to_vec())])
+    ///     [Token::Bytes(b"foo".to_vec())]
     /// );
     /// ```
     Bytes(Vec<u8>),
@@ -350,15 +326,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(
-    ///     Option::<()>::None.serialize(&serializer),
-    ///     Tokens(vec![Token::None])
-    /// );
+    /// assert_ok_eq!(Option::<()>::None.serialize(&serializer), [Token::None]);
     /// ```
     None,
 
@@ -371,15 +343,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(
-    ///     Some(()).serialize(&serializer),
-    ///     Tokens(vec![Token::Some, Token::Unit])
-    /// );
+    /// assert_ok_eq!(Some(()).serialize(&serializer), [Token::Some, Token::Unit]);
     /// ```
     Some,
 
@@ -392,12 +360,11 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
-    /// assert_ok_eq!(().serialize(&serializer), Tokens(vec![Token::Unit]));
+    /// assert_ok_eq!(().serialize(&serializer), [Token::Unit]);
     /// ```
     Unit,
 
@@ -410,7 +377,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     /// use serde_derive::Serialize;
     ///
@@ -421,7 +387,7 @@ pub enum Token {
     ///
     /// assert_ok_eq!(
     ///     UnitStruct.serialize(&serializer),
-    ///     Tokens(vec![Token::UnitStruct { name: "UnitStruct" }])
+    ///     [Token::UnitStruct { name: "UnitStruct" }]
     /// );
     /// ```
     UnitStruct { name: &'static str },
@@ -435,7 +401,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     /// use serde_derive::Serialize;
     ///
@@ -448,11 +413,11 @@ pub enum Token {
     ///
     /// assert_ok_eq!(
     ///     Enum::Unit.serialize(&serializer),
-    ///     Tokens(vec![Token::UnitVariant {
+    ///     [Token::UnitVariant {
     ///         name: "Enum",
     ///         variant_index: 0,
     ///         variant: "Unit"
-    ///     }])
+    ///     }]
     /// );
     /// ```
     UnitVariant {
@@ -470,7 +435,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     /// use serde_derive::Serialize;
     ///
@@ -481,12 +445,12 @@ pub enum Token {
     ///
     /// assert_ok_eq!(
     ///     NewtypeStruct(42).serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::NewtypeStruct {
     ///             name: "NewtypeStruct"
     ///         },
     ///         Token::U32(42)
-    ///     ])
+    ///     ]
     /// );
     /// ```
     NewtypeStruct { name: &'static str },
@@ -500,7 +464,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     /// use serde_derive::Serialize;
     ///
@@ -513,14 +476,14 @@ pub enum Token {
     ///
     /// assert_ok_eq!(
     ///     Enum::Newtype(42).serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::NewtypeVariant {
     ///             name: "Enum",
     ///             variant_index: 0,
     ///             variant: "Newtype"
     ///         },
     ///         Token::U32(42)
-    ///     ])
+    ///     ]
     /// );
     /// ```
     NewtypeVariant {
@@ -540,20 +503,19 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
     /// assert_ok_eq!(
     ///     vec![1u32, 2u32, 3u32].serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::Seq { len: Some(3) },
     ///         Token::U32(1),
     ///         Token::U32(2),
     ///         Token::U32(3),
     ///         Token::SeqEnd
-    ///     ])
+    ///     ]
     /// );
     /// ```
     ///
@@ -578,19 +540,18 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
     ///
     /// assert_ok_eq!(
     ///     (42u32, true).serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::Tuple { len: 2 },
     ///         Token::U32(42),
     ///         Token::Bool(true),
     ///         Token::TupleEnd
-    ///     ])
+    ///     ]
     /// );
     /// ```
     ///
@@ -615,7 +576,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     /// use serde_derive::Serialize;
     ///
@@ -626,7 +586,7 @@ pub enum Token {
     ///
     /// assert_ok_eq!(
     ///     TupleStruct(42u32, true).serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::TupleStruct {
     ///             name: "TupleStruct",
     ///             len: 2
@@ -634,7 +594,7 @@ pub enum Token {
     ///         Token::U32(42),
     ///         Token::Bool(true),
     ///         Token::TupleStructEnd
-    ///     ])
+    ///     ]
     /// );
     /// ```
     ///
@@ -659,7 +619,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     /// use serde_derive::Serialize;
     ///
@@ -673,7 +632,7 @@ pub enum Token {
     ///
     /// assert_ok_eq!(
     ///     Enum::Tuple(42u32, true).serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::TupleVariant {
     ///             name: "Enum",
     ///             variant_index: 0,
@@ -683,7 +642,7 @@ pub enum Token {
     ///         Token::U32(42),
     ///         Token::Bool(true),
     ///         Token::TupleVariantEnd
-    ///     ])
+    ///     ]
     /// );
     /// ```
     ///
@@ -714,7 +673,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
@@ -724,12 +682,12 @@ pub enum Token {
     ///
     /// assert_ok_eq!(
     ///     map.serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::Map { len: Some(1) },
     ///         Token::Str("foo".to_owned()),
     ///         Token::U32(42),
     ///         Token::MapEnd
-    ///     ])
+    ///     ]
     /// );
     /// ```
     ///
@@ -768,7 +726,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     /// use serde_derive::Serialize;
     ///
@@ -786,7 +743,7 @@ pub enum Token {
     ///         bar: true
     ///     }
     ///     .serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::Struct {
     ///             name: "Struct",
     ///             len: 2
@@ -796,7 +753,7 @@ pub enum Token {
     ///         Token::Field("bar"),
     ///         Token::Bool(true),
     ///         Token::StructEnd
-    ///     ])
+    ///     ]
     /// );
     /// ```
     ///
@@ -821,7 +778,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     /// use serde_derive::Serialize;
     ///
@@ -838,7 +794,7 @@ pub enum Token {
     ///         bar: true
     ///     }
     ///     .serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::StructVariant {
     ///             name: "Enum",
     ///             variant_index: 0,
@@ -850,7 +806,7 @@ pub enum Token {
     ///         Token::Field("bar"),
     ///         Token::Bool(true),
     ///         Token::StructVariantEnd
-    ///     ])
+    ///     ]
     /// );
     /// ```
     ///
@@ -889,7 +845,6 @@ pub enum Token {
     /// use serde_assert::{
     ///     Serializer,
     ///     Token,
-    ///     Tokens,
     /// };
     ///
     /// let serializer = Serializer::builder().build();
@@ -901,7 +856,7 @@ pub enum Token {
     ///
     /// assert_ok_eq!(
     ///     map.serialize(&serializer),
-    ///     Tokens(vec![
+    ///     [
     ///         Token::Map { len: Some(3) },
     ///         Token::Unordered(&[
     ///             &[Token::Char('a'), Token::U32(1)],
@@ -909,7 +864,7 @@ pub enum Token {
     ///             &[Token::Char('c'), Token::U32(3)]
     ///         ]),
     ///         Token::MapEnd
-    ///     ])
+    ///     ]
     /// );
     /// ```
     ///
@@ -1131,12 +1086,11 @@ impl<'a> From<&'a Token> for Unexpected<'a> {
 /// use serde_assert::{
 ///     Serializer,
 ///     Token,
-///     Tokens,
 /// };
 ///
 /// let serializer = Serializer::builder().build();
 ///
-/// assert_ok_eq!(true.serialize(&serializer), Tokens(vec![Token::Bool(true)]));
+/// assert_ok_eq!(true.serialize(&serializer), [Token::Bool(true)]);
 /// ```
 ///
 /// ## Deserialization
@@ -1147,12 +1101,9 @@ impl<'a> From<&'a Token> for Unexpected<'a> {
 /// use serde_assert::{
 ///     Deserializer,
 ///     Token,
-///     Tokens,
 /// };
 ///
-/// let mut deserializer = Deserializer::builder()
-///     .tokens(Tokens(vec![Token::Bool(true)]))
-///     .build();
+/// let mut deserializer = Deserializer::builder().tokens([Token::Bool(true)]).build();
 ///
 /// assert_ok_eq!(bool::deserialize(&mut deserializer), true);
 /// ```

--- a/src/token.rs
+++ b/src/token.rs
@@ -7,7 +7,6 @@
 use alloc::{
     slice,
     string::String,
-    vec,
     vec::Vec,
 };
 use core::{
@@ -1174,10 +1173,13 @@ where
     }
 }
 
-impl Tokens {
-    fn eq(&self, other: &Self) -> bool {
+impl<T> PartialEq<T> for Tokens
+where
+    for<'a> &'a T: IntoIterator<Item = &'a Token>,
+{
+    fn eq(&self, other: &T) -> bool {
         let mut self_iter = self.0.iter();
-        let mut other_iter = other.0.iter();
+        let mut other_iter = other.into_iter();
 
         loop {
             // Obtain next tokens, or return if no tokens are available.
@@ -1235,42 +1237,13 @@ impl Tokens {
     }
 }
 
-impl PartialEq for Tokens {
-    fn eq(&self, other: &Self) -> bool {
-        self.eq(other)
-    }
-}
-
-impl PartialEq<Vec<Token>> for Tokens {
-    fn eq(&self, other: &Vec<Token>) -> bool {
-        self.eq(&Tokens(other.clone()))
-    }
-}
-
-impl<const N: usize> PartialEq<[Token; N]> for Tokens {
-    fn eq(&self, other: &[Token; N]) -> bool {
-        self.eq(&Tokens(other.to_vec()))
-    }
-}
-
-impl PartialEq<Tokens> for Vec<Token> {
-    fn eq(&self, other: &Tokens) -> bool {
-        other.eq(&Tokens(self.clone()))
-    }
-}
-
-impl<const N: usize> PartialEq<Tokens> for [Token; N] {
-    fn eq(&self, other: &Tokens) -> bool {
-        other.eq(&Tokens(self.to_vec()))
-    }
-}
-
-impl IntoIterator for Tokens {
-    type Item = Token;
-    type IntoIter = vec::IntoIter<Token>;
+#[allow(clippy::into_iter_without_iter)]
+impl<'a> IntoIterator for &'a Tokens {
+    type Item = &'a Token;
+    type IntoIter = slice::Iter<'a, Token>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.0.iter()
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1111,7 +1111,7 @@ impl<'a> From<&'a Token> for Unexpected<'a> {
 /// [`Deserializer`]: crate::Deserializer
 /// [`Serializer`]: crate::Serializer
 #[derive(Clone, Debug)]
-pub struct Tokens(pub Vec<Token>);
+pub struct Tokens(pub(crate) Vec<Token>);
 
 fn consume_unordered<'a, I>(unordered_tokens: &[&[Token]], mut tokens_iter: I) -> bool
 where

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,0 +1,24 @@
+use claims::{
+    assert_ok,
+    assert_ok_eq,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use serde_assert::{
+    Deserializer,
+    Serializer,
+};
+
+#[test]
+fn roundtrip() {
+    let value = true;
+
+    let serializer = Serializer::builder().build();
+    let mut deserializer = Deserializer::builder()
+        .tokens(assert_ok!(value.serialize(&serializer)))
+        .build();
+
+    assert_ok_eq!(bool::deserialize(&mut deserializer), value);
+}


### PR DESCRIPTION
Fixes #20.

Note that this does not fully remove the `Tokens` type. This pull request simply removes the need to explicitly use the `Tokens` type as a user, eliminating the unnecessary boilerplate that was previously required. Now, any type that implements `IntoIterator<Token>` can be used.