### PR TITLE
Remove separate `serde_derive` imports from doc tests.

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -62,7 +62,7 @@ use serde::{
 ///     Serializer,
 ///     Token,
 /// };
-/// use serde_derive::Serialize;
+/// # use serde_derive::Serialize;
 ///
 /// #[derive(Serialize)]
 /// struct Struct {
@@ -459,7 +459,7 @@ impl Builder {
     ///     Serializer,
     ///     Token,
     /// };
-    /// use serde_derive::Serialize;
+    /// # use serde_derive::Serialize;
     ///
     /// #[derive(Serialize)]
     /// struct Struct {

--- a/src/token.rs
+++ b/src/token.rs
@@ -381,7 +381,7 @@ pub enum Token {
     ///     Serializer,
     ///     Token,
     /// };
-    /// use serde_derive::Serialize;
+    /// # use serde_derive::Serialize;
     ///
     /// #[derive(Serialize)]
     /// struct UnitStruct;
@@ -405,7 +405,7 @@ pub enum Token {
     ///     Serializer,
     ///     Token,
     /// };
-    /// use serde_derive::Serialize;
+    /// # use serde_derive::Serialize;
     ///
     /// #[derive(Serialize)]
     /// enum Enum {
@@ -439,7 +439,7 @@ pub enum Token {
     ///     Serializer,
     ///     Token,
     /// };
-    /// use serde_derive::Serialize;
+    /// # use serde_derive::Serialize;
     ///
     /// #[derive(Serialize)]
     /// struct NewtypeStruct(u32);
@@ -468,7 +468,7 @@ pub enum Token {
     ///     Serializer,
     ///     Token,
     /// };
-    /// use serde_derive::Serialize;
+    /// # use serde_derive::Serialize;
     ///
     /// #[derive(Serialize)]
     /// enum Enum {
@@ -580,7 +580,7 @@ pub enum Token {
     ///     Serializer,
     ///     Token,
     /// };
-    /// use serde_derive::Serialize;
+    /// # use serde_derive::Serialize;
     ///
     /// #[derive(Serialize)]
     /// struct TupleStruct(u32, bool);
@@ -623,7 +623,7 @@ pub enum Token {
     ///     Serializer,
     ///     Token,
     /// };
-    /// use serde_derive::Serialize;
+    /// # use serde_derive::Serialize;
     ///
     /// #[derive(Serialize)]
     /// enum Enum {
@@ -730,7 +730,7 @@ pub enum Token {
     ///     Serializer,
     ///     Token,
     /// };
-    /// use serde_derive::Serialize;
+    /// # use serde_derive::Serialize;
     ///
     /// #[derive(Serialize)]
     /// struct Struct {
@@ -782,7 +782,7 @@ pub enum Token {
     ///     Serializer,
     ///     Token,
     /// };
-    /// use serde_derive::Serialize;
+    /// # use serde_derive::Serialize;
     ///
     /// #[derive(Serialize)]
     /// enum Enum {


### PR DESCRIPTION
`serde` currently [recommends](https://serde.rs/derive.html) to use the `derive` feature and not depend on `serde_derive` directly (although this recommendation may change, see discussion in https://github.com/serde-rs/serde/issues/2584). Therefore, this library should also not recommend using `serde_derive` directly either, so as not to create confusion.

Additionally, this has the benefit of shortening the doc-test examples.