### PR TITLE
Overhaul of `Builder` APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `&Tokens` now implements `IntoIterator<Item = &Token>`.
 - The `token` module is now public, containing both `Token` (which is also exposed in the root module) and `Tokens`.
 ### Changed
-- `de::Builder::tokens()` now accepts any type that implements `IntoIterator<Item = Token>`.
+- `Deserializer::build()` now takes the tokens as a parameter. These tokens can now be any type that implements `IntoIterator<Item = Token>`.
 - `Tokens` is no longer exposed in the root module, instead being available at `token::Tokens`.
 - The internals of `Tokens` are no longer public. `Tokens` can no longer be constructed by user code, and is now only returned by the `Serializer`.
 - Comparison with a `Tokens` can now be done with any type that implements `IntoIterator<Item = &Token>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `Tokens` is no longer exposed in the root module, instead being available at `token::Tokens`.
 - The internals of `Tokens` are no longer public. `Tokens` can no longer be constructed by user code, and is now only returned by the `Serializer`.
 - Comparison with a `Tokens` can now be done with any type that implements `IntoIterator<Item = &Token>`.
+- `de::Builder::build()` now only requires `&self` instead of `&mut self`.
 
 ## 0.6.0 - 2023-11-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `&Tokens` now implements `IntoIterator<Item = &Token>`.
 - The `token` module is now public, containing both `Token` (which is also exposed in the root module) and `Tokens`.
 ### Changed
-- `de::Builder::tokens()` now accepts any type that implements `Clone + IntoIterator<Item = Token>`.
+- `de::Builder::tokens()` now accepts any type that implements `IntoIterator<Item = Token>`.
 - `Tokens` is no longer exposed in the root module, instead being available at `token::Tokens`.
 - The internals of `Tokens` are no longer public. `Tokens` can no longer be constructed by user code, and is now only returned by the `Serializer`.
 - Comparison with a `Tokens` can now be done with any type that implements `IntoIterator<Item = &Token>`.

--- a/src/de.rs
+++ b/src/de.rs
@@ -1189,13 +1189,13 @@ impl<'a, 'de> de::Deserializer<'de> for EnumDeserializer<'a, 'de> {
 ///
 /// [`build()`]: Builder::build()
 /// [`tokens()`]: Builder::tokens()
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Builder {
     tokens: Option<Tokens>,
 
-    is_human_readable: Option<bool>,
-    self_describing: Option<bool>,
-    zero_copy: Option<bool>,
+    is_human_readable: bool,
+    self_describing: bool,
+    zero_copy: bool,
 }
 
 impl Builder {
@@ -1243,7 +1243,7 @@ impl Builder {
     ///     .build();
     /// ```
     pub fn is_human_readable(&mut self, is_human_readable: bool) -> &mut Self {
-        self.is_human_readable = Some(is_human_readable);
+        self.is_human_readable = is_human_readable;
         self
     }
 
@@ -1270,7 +1270,7 @@ impl Builder {
     ///
     /// [`deserialize_any()`]: ../struct.Deserializer.html#method.deserialize_any
     pub fn self_describing(&mut self, self_describing: bool) -> &mut Self {
-        self.self_describing = Some(self_describing);
+        self.self_describing = self_describing;
         self
     }
 
@@ -1295,7 +1295,7 @@ impl Builder {
     ///     .build();
     /// ```
     pub fn zero_copy(&mut self, zero_copy: bool) -> &mut Self {
-        self.zero_copy = Some(zero_copy);
+        self.zero_copy = zero_copy;
         self
     }
 
@@ -1328,9 +1328,21 @@ impl Builder {
 
             revisited_token: None,
 
-            is_human_readable: self.is_human_readable.unwrap_or(true),
-            self_describing: self.self_describing.unwrap_or(false),
-            zero_copy: self.zero_copy.unwrap_or(true),
+            is_human_readable: self.is_human_readable,
+            self_describing: self.self_describing,
+            zero_copy: self.zero_copy,
+        }
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            tokens: None,
+
+            is_human_readable: true,
+            self_describing: false,
+            zero_copy: true,
         }
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1318,7 +1318,7 @@ impl Builder {
     ///
     /// # Panics
     /// This method will panic if [`Builder::tokens()`] was never called.
-    pub fn build<'a>(&mut self) -> Deserializer<'a> {
+    pub fn build<'a>(&self) -> Deserializer<'a> {
         Deserializer {
             tokens: token::Iter::new(
                 self.tokens

--- a/src/de.rs
+++ b/src/de.rs
@@ -1174,8 +1174,6 @@ impl<'a, 'de> de::Deserializer<'de> for EnumDeserializer<'a, 'de> {
 /// Construction of a `Deserializer` follows the builder pattern. Configuration options can be set
 /// on the `Builder`, and then the actual `Deserializer` is constructed by calling [`build()`].
 ///
-/// Note that providing a sequence of [`Token`]s using the [::builder()`] method is required.
-///
 /// # Example
 /// ``` rust
 /// use serde_assert::{
@@ -1304,6 +1302,7 @@ impl Builder {
     ///     .is_human_readable(false)
     ///     .build();
     /// ```
+    #[must_use]
     pub fn build<'a>(&self) -> Deserializer<'a> {
         Deserializer {
             tokens: token::Iter::new(self.tokens.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //!     Token,
 //! };
 //!
-//! let mut deserializer = Deserializer::builder().tokens([Token::Bool(true)]).build();
+//! let mut deserializer = Deserializer::builder([Token::Bool(true)]).build();
 //!
 //! assert_ok_eq!(bool::deserialize(&mut deserializer), true);
 //! ```
@@ -95,9 +95,7 @@
 //! let value = true;
 //!
 //! let serializer = Serializer::builder().build();
-//! let mut deserializer = Deserializer::builder()
-//!     .tokens(assert_ok!(value.serialize(&serializer)))
-//!     .build();
+//! let mut deserializer = Deserializer::builder(assert_ok!(value.serialize(&serializer))).build();
 //!
 //! assert_ok_eq!(bool::deserialize(&mut deserializer), value);
 //! ```

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -414,10 +414,10 @@ impl Serializer {
 /// ```
 ///
 /// [`build()`]: Builder::build()
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Builder {
-    is_human_readable: Option<bool>,
-    serialize_struct_as: Option<SerializeStructAs>,
+    is_human_readable: bool,
+    serialize_struct_as: SerializeStructAs,
 }
 
 impl Builder {
@@ -436,7 +436,7 @@ impl Builder {
     /// let serializer = Serializer::builder().is_human_readable(false).build();
     /// ```
     pub fn is_human_readable(&mut self, is_human_readable: bool) -> &mut Self {
-        self.is_human_readable = Some(is_human_readable);
+        self.is_human_readable = is_human_readable;
         self
     }
 
@@ -484,7 +484,7 @@ impl Builder {
     /// );
     /// ```
     pub fn serialize_struct_as(&mut self, serialize_struct_as: SerializeStructAs) -> &mut Self {
-        self.serialize_struct_as = Some(serialize_struct_as);
+        self.serialize_struct_as = serialize_struct_as;
         self
     }
 
@@ -500,10 +500,17 @@ impl Builder {
     /// ```
     pub fn build(&mut self) -> Serializer {
         Serializer {
-            is_human_readable: self.is_human_readable.unwrap_or(true),
-            serialize_struct_as: self
-                .serialize_struct_as
-                .unwrap_or(SerializeStructAs::Struct),
+            is_human_readable: self.is_human_readable,
+            serialize_struct_as: self.serialize_struct_as,
+        }
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            is_human_readable: true,
+            serialize_struct_as: SerializeStructAs::Struct,
         }
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -1110,9 +1110,7 @@ impl<'a> From<&'a Token> for Unexpected<'a> {
 /// };
 ///
 /// let serializer = Serializer::builder().build();
-/// let mut deserializer = Deserializer::builder()
-///     .tokens(assert_ok!(true.serialize(&serializer)))
-///     .build();
+/// let mut deserializer = Deserializer::builder(assert_ok!(true.serialize(&serializer))).build();
 ///
 /// assert_ok_eq!(bool::deserialize(&mut deserializer), true);
 /// ```

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -16,9 +16,7 @@ fn roundtrip() {
     let value = true;
 
     let serializer = Serializer::builder().build();
-    let mut deserializer = Deserializer::builder()
-        .tokens(assert_ok!(value.serialize(&serializer)))
-        .build();
+    let mut deserializer = Deserializer::builder(assert_ok!(value.serialize(&serializer))).build();
 
     assert_ok_eq!(bool::deserialize(&mut deserializer), value);
 }


### PR DESCRIPTION
Fixes #17.

This fixes a few things in the `de::Builder` API. Firstly, this makes it impossible for `build()` to panic, instead requiring that `Builder` is always in a valid state (meaning `tokens` is always set). Additionally, the internals of `Builder` are refactored to no longer use any `Option`s, as well as collecting the tokens preemptively to prevent having to clone an iterator.